### PR TITLE
Revert "Make NBTSerializable more like forge"

### DIFF
--- a/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/AbstractMinecartMixin.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/AbstractMinecartMixin.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import io.github.fabricators_of_create.porting_lib.block.MinecartPassHandlerBlock;
 import io.github.fabricators_of_create.porting_lib.extensions.AbstractMinecartExtensions;
-import io.github.fabricators_of_create.porting_lib.util.INBTSerializable;
+import io.github.fabricators_of_create.porting_lib.util.NBTSerializable;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -25,7 +25,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
 
 @Mixin(AbstractMinecart.class)
-public abstract class AbstractMinecartMixin extends Entity implements AbstractMinecartExtensions, INBTSerializable<CompoundTag> {
+public abstract class AbstractMinecartMixin extends Entity implements AbstractMinecartExtensions, NBTSerializable {
 	private AbstractMinecartMixin(EntityType<?> entityType, Level world) {
 		super(entityType, world);
 	}

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/BlockEntityMixin.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/BlockEntityMixin.java
@@ -9,13 +9,13 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import io.github.fabricators_of_create.porting_lib.extensions.BlockEntityExtensions;
 import io.github.fabricators_of_create.porting_lib.util.BlockEntityHelper;
-import io.github.fabricators_of_create.porting_lib.util.INBTSerializable;
+import io.github.fabricators_of_create.porting_lib.util.NBTSerializable;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 
 @Mixin(BlockEntity.class)
-public abstract class BlockEntityMixin implements BlockEntityExtensions, INBTSerializable<CompoundTag> {
+public abstract class BlockEntityMixin implements BlockEntityExtensions, NBTSerializable {
 	@Unique
 	private CompoundTag port_lib$extraData = null;
 

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/EntityMixin.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/EntityMixin.java
@@ -9,7 +9,7 @@ import io.github.fabricators_of_create.porting_lib.extensions.EntityExtensions;
 import io.github.fabricators_of_create.porting_lib.extensions.ITeleporter;
 import io.github.fabricators_of_create.porting_lib.extensions.RegistryNameProvider;
 import io.github.fabricators_of_create.porting_lib.util.EntityHelper;
-import io.github.fabricators_of_create.porting_lib.util.INBTSerializable;
+import io.github.fabricators_of_create.porting_lib.util.NBTSerializable;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
@@ -39,7 +39,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 
 @Mixin(Entity.class)
-public abstract class EntityMixin implements EntityExtensions, INBTSerializable<CompoundTag>, RegistryNameProvider {
+public abstract class EntityMixin implements EntityExtensions, NBTSerializable, RegistryNameProvider {
 	@Shadow
 	public Level level;
 	@Shadow

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/ItemStackMixin.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/ItemStackMixin.java
@@ -23,14 +23,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import io.github.fabricators_of_create.porting_lib.item.CustomMaxCountItem;
-import io.github.fabricators_of_create.porting_lib.util.INBTSerializable;
+import io.github.fabricators_of_create.porting_lib.util.NBTSerializable;
 
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 
 @Mixin(ItemStack.class)
-public abstract class ItemStackMixin implements INBTSerializable<CompoundTag>, ItemStackExtensions {
+public abstract class ItemStackMixin implements NBTSerializable, ItemStackExtensions {
 
 	@Shadow
 	public abstract CompoundTag save(CompoundTag compoundTag);

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandler.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandler.java
@@ -4,7 +4,7 @@ import io.github.fabricators_of_create.porting_lib.transfer.callbacks.Transactio
 import io.github.fabricators_of_create.porting_lib.transfer.callbacks.TransactionSuccessCallback;
 import io.github.fabricators_of_create.porting_lib.transfer.item.ItemStackHandler.SnapshotData;
 import io.github.fabricators_of_create.porting_lib.util.ItemStackUtil;
-import io.github.fabricators_of_create.porting_lib.util.INBTSerializable;
+import io.github.fabricators_of_create.porting_lib.util.NBTSerializable;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Iterator;
 
-public class ItemStackHandler extends SnapshotParticipant<SnapshotData> implements Storage<ItemVariant>, INBTSerializable<CompoundTag> {
+public class ItemStackHandler extends SnapshotParticipant<SnapshotData> implements Storage<ItemVariant>, NBTSerializable {
 	public ItemStack[] stacks;
 
 	public ItemStackHandler() {

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/util/INBTSerializable.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/util/INBTSerializable.java
@@ -1,9 +1,0 @@
-package io.github.fabricators_of_create.porting_lib.util;
-
-import net.minecraft.nbt.Tag;
-
-public interface INBTSerializable<T extends Tag> {
-	T serializeNBT();
-
-	void deserializeNBT(T nbt);
-}

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/util/NBTSerializable.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/util/NBTSerializable.java
@@ -1,0 +1,9 @@
+package io.github.fabricators_of_create.porting_lib.util;
+
+import net.minecraft.nbt.CompoundTag;
+
+public interface NBTSerializable {
+	CompoundTag serializeNBT();
+
+	void deserializeNBT(CompoundTag nbt);
+}

--- a/src/main/java/io/github/fabricators_of_create/porting_lib/util/NBTSerializer.java
+++ b/src/main/java/io/github/fabricators_of_create/porting_lib/util/NBTSerializer.java
@@ -1,0 +1,13 @@
+package io.github.fabricators_of_create.porting_lib.util;
+
+import net.minecraft.nbt.CompoundTag;
+
+public class NBTSerializer {
+	public static void deserializeNBT(Object o, CompoundTag nbt) {
+		((NBTSerializable) o).deserializeNBT(nbt);
+	}
+
+	public static CompoundTag serializeNBT(Object o) {
+		return ((NBTSerializable) o).serializeNBT();
+	}
+}


### PR DESCRIPTION
Reverts Fabricators-of-Create/Porting-Lib#6
Lets not change huge things for no reason?
NBTSerializer is used a *lot* by the way