### PR TITLE
Adds ModMenu `library` badge.

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -100,6 +100,9 @@
       "net/minecraft/class_4184": ["io/github/fabricators_of_create/porting_lib/extensions/CameraExtensions"],
       "net/minecraft/class_4590": ["io/github/fabricators_of_create/porting_lib/extensions/TransformationExtensions"],
       "net/minecraft/class_4581": ["io/github/fabricators_of_create/porting_lib/extensions/Matrix3fExtensions"]
+    },
+    "modmenu": {
+      "badges": [ "library" ]
     }
   }
 }


### PR DESCRIPTION
This allows to filter library mods in [ModMenu](https://github.com/TerraformersMC/ModMenu/wiki/API#badges).