### PR TITLE
Don't throw in LevelExtensions default impl

### DIFF
--- a/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/extensions/transfer/LevelExtensions.java
+++ b/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/extensions/transfer/LevelExtensions.java
@@ -1,5 +1,7 @@
 package io.github.fabricators_of_create.porting_lib.extensions.transfer;
 
+import io.github.fabricators_of_create.porting_lib.transfer.cache.EmptyFluidLookupCache;
+import io.github.fabricators_of_create.porting_lib.transfer.cache.EmptyItemLookupCache;
 import net.fabricmc.fabric.api.lookup.v1.block.BlockApiCache;
 import net.fabricmc.fabric.api.transfer.v1.fluid.FluidVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
@@ -9,10 +11,11 @@ import net.minecraft.core.Direction;
 
 public interface LevelExtensions {
 	default BlockApiCache<Storage<ItemVariant>, Direction> port_lib$getItemCache(BlockPos pos) {
-		throw new RuntimeException("this should be overridden via mixin. what?");
+		// litematica compat: don't throw, just return empty
+		return EmptyItemLookupCache.INSTANCE;
 	}
 
 	default BlockApiCache<Storage<FluidVariant>, Direction> port_lib$getFluidApiCache(BlockPos pos) {
-		throw new RuntimeException("this should be overridden via mixin. what?");
+		return EmptyFluidLookupCache.INSTANCE;
 	}
 }


### PR DESCRIPTION
Litematica (a client-side schematic mod, see https://github.com/maruohon/litematica) has its own Level implementation (`WorldSchematic`) which apparently does not inherit mixin methods from `Level`. Create tile entities in schematics cause crashes during rendering due to the exception. Removing it fixes the crash.

I'm not sure if this is desired. Please close if it is not.