### PR TITLE
Ensure ItemStackHandlerSlot.lastStack is not unexpectedly mutated

### DIFF
--- a/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
+++ b/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
@@ -14,7 +14,7 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 	private final ItemStackHandler handler;
 	private ItemStack stack = ItemStack.EMPTY;
 	private ItemStack lastStack; // last stack pre-transaction
-	private int lastStackCount; // Because this isn't Rust so our entire universe is a lie
+	private int lastStackCount; // Temporary fix for ItemStack mutation
 	private ItemVariant variant = ItemVariant.blank();
 
 	public ItemStackHandlerSlot(int index, ItemStackHandler handler, ItemStack initial) {
@@ -72,7 +72,7 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 
 	protected void onStackChange() {
 		if (this.lastStack.getCount() != this.lastStackCount) {
-			PortingLib.LOGGER.warn("lastStack.getCount() differs from this.lastStackCount!! _This would never happen in Rustlang_");
+			PortingLib.LOGGER.warn("this.lastStack.getCount() differs from this.lastStackCount! Who mutated this??");
 			this.lastStack.setCount(this.lastStackCount);
 		}
 		handler.onStackChange(this, lastStack, stack);

--- a/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
+++ b/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
@@ -1,5 +1,6 @@
 package io.github.fabricators_of_create.porting_lib.transfer.item;
 
+import io.github.fabricators_of_create.porting_lib.core.PortingLib;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
 
@@ -13,12 +14,14 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 	private final ItemStackHandler handler;
 	private ItemStack stack = ItemStack.EMPTY;
 	private ItemStack lastStack; // last stack pre-transaction
+	private int lastStackCount; // Because this isn't Rust so our entire universe is a lie
 	private ItemVariant variant = ItemVariant.blank();
 
 	public ItemStackHandlerSlot(int index, ItemStackHandler handler, ItemStack initial) {
 		this.index = index;
 		this.handler = handler;
 		this.lastStack = initial;
+		this.lastStackCount = initial.getCount();
 		this.setStack(initial);
 		handler.initSlot(this);
 	}
@@ -68,8 +71,13 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 	}
 
 	protected void onStackChange() {
+		if (this.lastStack.getCount() != this.lastStackCount) {
+			PortingLib.LOGGER.warn("lastStack.getCount() differs from this.lastStackCount!! _This would never happen in Rustlang_");
+			this.lastStack.setCount(this.lastStackCount);
+		}
 		handler.onStackChange(this, lastStack, stack);
 		this.lastStack = stack.copy();
+		this.lastStackCount = lastStack.getCount();
 	}
 
 	protected void notifyHandlerOfChange() {

--- a/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
+++ b/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
@@ -69,7 +69,7 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 
 	protected void onStackChange() {
 		handler.onStackChange(this, lastStack, stack);
-		this.lastStack = stack;
+		this.lastStack = stack.copy();
 	}
 
 	protected void notifyHandlerOfChange() {

--- a/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
+++ b/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandlerSlot.java
@@ -1,6 +1,5 @@
 package io.github.fabricators_of_create.porting_lib.transfer.item;
 
-import io.github.fabricators_of_create.porting_lib.core.PortingLib;
 import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
 import net.fabricmc.fabric.api.transfer.v1.item.base.SingleStackStorage;
 
@@ -14,14 +13,12 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 	private final ItemStackHandler handler;
 	private ItemStack stack = ItemStack.EMPTY;
 	private ItemStack lastStack; // last stack pre-transaction
-	private int lastStackCount; // Temporary fix for ItemStack mutation
 	private ItemVariant variant = ItemVariant.blank();
 
 	public ItemStackHandlerSlot(int index, ItemStackHandler handler, ItemStack initial) {
 		this.index = index;
 		this.handler = handler;
-		this.lastStack = initial;
-		this.lastStackCount = initial.getCount();
+		this.lastStack = initial.copy();
 		this.setStack(initial);
 		handler.initSlot(this);
 	}
@@ -71,13 +68,8 @@ public class ItemStackHandlerSlot extends SingleStackStorage {
 	}
 
 	protected void onStackChange() {
-		if (this.lastStack.getCount() != this.lastStackCount) {
-			PortingLib.LOGGER.warn("this.lastStack.getCount() differs from this.lastStackCount! Who mutated this??");
-			this.lastStack.setCount(this.lastStackCount);
-		}
 		handler.onStackChange(this, lastStack, stack);
 		this.lastStack = stack.copy();
-		this.lastStackCount = lastStack.getCount();
 	}
 
 	protected void notifyHandlerOfChange() {


### PR DESCRIPTION
Greetings fabricators of create.

This patch will prevent servers crashing when contraptions turn into blocks after shift+clicking to remove items from contraption inventories.

As per our discussion via discord, I understand needless copying may be bad form, though in my opinion, it's the only way to ensure that `lastStack` will not be mutated and comes at a negligible performance impact.

Happy to be of help.