### PR TITLE
Fix ServerLevelMixin incorrectly unloading levels with force-loaded chunks

### DIFF
--- a/modules/chunk_loading/src/main/java/io/github/fabricators_of_create/porting_lib/chunk/loading/mixin/ServerLevelMixin.java
+++ b/modules/chunk_loading/src/main/java/io/github/fabricators_of_create/porting_lib/chunk/loading/mixin/ServerLevelMixin.java
@@ -5,14 +5,19 @@ import it.unimi.dsi.fastutil.longs.LongSet;
 import net.minecraft.server.level.ServerLevel;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerLevel.class)
-public class ServerLevelMixin {
+public abstract class ServerLevelMixin {
+	@Shadow
+	public abstract LongSet getForcedChunks();
+
 	// Future me see if this can be replaced with a modify expression
 	@Redirect(method = "tick", at = @At(value = "INVOKE", target = "Lit/unimi/dsi/fastutil/longs/LongSet;isEmpty()Z"))
 	private boolean hasChunks(LongSet instance) {
-		return PortingLibChunkManager.hasForcedChunks((ServerLevel) (Object) this);
+		//noinspection ConstantValue
+		return getForcedChunks().isEmpty() && !PortingLibChunkManager.hasForcedChunks((ServerLevel) (Object) this);
 	}
 }


### PR DESCRIPTION
The condition should be flipped because we are redirecting the `isEmpty` call. Vanilla forced chunks should also be checked because the original call has been redirected.