### PR TITLE
[1.21] Fix ExplosionMixin

### DIFF
--- a/modules/base/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/ExplosionMixin.java
+++ b/modules/base/src/main/java/io/github/fabricators_of_create/porting_lib/mixin/common/ExplosionMixin.java
@@ -24,7 +24,7 @@ public abstract class ExplosionMixin {
 	private Level level;
 
 	@Inject(method = "explode", at = @At(value = "NEW", target = "net/minecraft/world/phys/Vec3", ordinal = 1), locals = LocalCapture.CAPTURE_FAILHARD)
-	public void onExplode(CallbackInfo ci, Set<BlockPos> blocks, float j, int k, int l, int r, int s, int t, int u, List<Entity> list) {
+	public void onExplode(CallbackInfo ci, Set<BlockPos> blocks, int i, float j, int k, int l, int r, int s, int t, int u, List<Entity> list) {
 		ExplosionEvents.DETONATE.invoker().onDetonate(this.level, (Explosion) (Object) this, list, j);
 	}
 }


### PR DESCRIPTION
A local variable was missing from the `onExplode` method, causing the game to crash when explosions happen.
More info can found here: https://github.com/MehVahdJukaar/FarmersDelightRefabricated/issues/68