### PR TITLE
[1.21] Fix empty slots having a slot limit of 1 in ItemStackHandler.

### DIFF
--- a/modules/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandler.java
+++ b/modules/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandler.java
@@ -138,7 +138,7 @@ public class ItemStackHandler implements SlottedStackStorage, INBTSerializable<C
 	}
 
 	public int getSlotLimit(int slot) {
-		return getStackInSlot(slot).getOrDefault(DataComponents.MAX_STACK_SIZE, 99);
+		return getStackInSlot(slot).getOrDefault(DataComponents.MAX_STACK_SIZE, Integer.MAX_VALUE);
 	}
 
 	/**

--- a/modules/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandler.java
+++ b/modules/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemStackHandler.java
@@ -12,6 +12,7 @@ import net.fabricmc.fabric.api.transfer.v1.storage.StorageView;
 import net.fabricmc.fabric.api.transfer.v1.storage.base.SingleSlotStorage;
 import net.fabricmc.fabric.api.transfer.v1.transaction.TransactionContext;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.Tag;
@@ -137,7 +138,7 @@ public class ItemStackHandler implements SlottedStackStorage, INBTSerializable<C
 	}
 
 	public int getSlotLimit(int slot) {
-		return getStackInSlot(slot).getMaxStackSize();
+		return getStackInSlot(slot).getOrDefault(DataComponents.MAX_STACK_SIZE, 99);
 	}
 
 	/**


### PR DESCRIPTION
By using ItemStack#getMaxStackSize, you are limiting any empty slot to have a slot limit of 1, as that defaults to 1 when there is no max stack size component present (empty stacks don't have it).

The fix is to instead getOrDefault the stack size component and default it to max value, that way, mods that increase the max stack size further than 99 can also be slotted into empty slots.