### PR TITLE
fix EntityInteractCallback not reaching server if canceled on client

### DIFF
--- a/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/client/MultiPlayerGameModeMixin.java
+++ b/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/client/MultiPlayerGameModeMixin.java
@@ -40,10 +40,10 @@ public class MultiPlayerGameModeMixin {
 	@Shadow
 	private GameType localPlayerMode;
 
-	@Inject(method = "interact", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/protocol/game/ServerboundInteractPacket;createInteractionPacket(Lnet/minecraft/world/entity/Entity;ZLnet/minecraft/world/InteractionHand;)Lnet/minecraft/network/protocol/game/ServerboundInteractPacket;"), cancellable = true)
+	@Inject(method = "interact", at = @At(value = "INVOKE", shift = At.Shift.AFTER, target = "Lnet/minecraft/client/multiplayer/ClientPacketListener;send(Lnet/minecraft/network/protocol/Packet;)V"), cancellable = true)
 	public void port_lib$onEntityInteract(Player player, Entity target, InteractionHand hand, CallbackInfoReturnable<InteractionResult> cir) {
 		if (this.localPlayerMode != GameType.SPECTATOR) { // don't fire for spectators to match non-specific EntityInteract
-			InteractionResult cancelResult = EntityInteractCallback.EVENT.invoker().onEntityInteract(player, hand, target);
+			InteractionResult cancelResult 	= EntityInteractCallback.EVENT.invoker().onEntityInteract(player, hand, target);
 			if (cancelResult != null) cir.setReturnValue(cancelResult);
 		}
 	}

--- a/modules/entity/src/testmod/java/io/github/fabricators_of_create/porting_lib/entity/testmod/PortingLibEntityTestmod.java
+++ b/modules/entity/src/testmod/java/io/github/fabricators_of_create/porting_lib/entity/testmod/PortingLibEntityTestmod.java
@@ -1,15 +1,20 @@
 package io.github.fabricators_of_create.porting_lib.entity.testmod;
 
+import io.github.fabricators_of_create.porting_lib.entity.events.EntityInteractCallback;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.EntityDimensions;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.MobCategory;
 import net.minecraft.world.entity.monster.Monster;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 
 public class PortingLibEntityTestmod implements ModInitializer {
 
@@ -27,5 +32,19 @@ public class PortingLibEntityTestmod implements ModInitializer {
 				CUSTOM_SLIME
 		);
 		FabricDefaultAttributeRegistry.register(CUSTOM_SLIME, Monster.createMonsterAttributes());
+
+		EntityInteractCallback.EVENT.register((player, hand, target) -> {
+			ItemStack held = player.getItemInHand(hand);
+			if (target.getType() != EntityType.COW) return null;
+			if (!held.is(Items.BUCKET)) return null;
+
+			var isClient = player.level().isClientSide();
+
+			if(!isClient) {
+				player.setItemInHand(hand, new ItemStack(Items.LAVA_BUCKET));
+			}
+
+			return InteractionResult.sidedSuccess(isClient);
+		});
 	}
 }


### PR DESCRIPTION
*This is a proposed fix for #135*

This changes the cancelation of the injected method to happen after the `ServerboundInteractPacket` has been send to the server instead of before. This means that returning a non-null `InteractionResult` on client now still triggers the `EntityInteractCallback` on the server too instead of omitting it.

I have also added an example callback to the test mod to check if this actually solves the issue, I have left it in, but can also remove it again if you want to.