### PR TITLE
Fix incorrect interface injection in Brewing Module.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,8 @@ allprojects {
 
 				// property replacement is a bit too eager
 				class_5124: "\$class_5124",
-				class_56: "\$class_56"
+				class_56: "\$class_56",
+                class_9665: "\$class_9665"
 		]
 
 		properties.forEach(inputs::property)

--- a/modules/brewing/src/main/resources/fabric.mod.json
+++ b/modules/brewing/src/main/resources/fabric.mod.json
@@ -7,7 +7,7 @@
   "custom": {
     "loom:injected_interfaces": {
       "net/minecraft/class_1845": ["io/github/fabricators_of_create/porting_lib/brewing/ext/PotionBrewingExt"],
-      "net/minecraft/class_1845/class_9665": ["io/github/fabricators_of_create/porting_lib/brewing/ext/PotionBrewingBuilderExt"]
+      "net/minecraft/class_1845$class_9665": ["io/github/fabricators_of_create/porting_lib/brewing/ext/PotionBrewingBuilderExt"]
     }
   }
 }


### PR DESCRIPTION
The `/` indicates that it's in a subfolder. You need `$`, which causes minor issues with property replacement but can be fixed.