### PR TITLE
Allow playing on 1.21.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ allprojects {
 		Map<String, ?> properties = [
 				version: version,
 				loader_version: loader_version,
-				fabric_api_version: fabric_api_version,
+				fabric_api_dependency: fabric_api_dependency,
 				minecraft_dependency: minecraft_dependency,
 				java_version: sourceCompatibility,
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,9 +8,10 @@ mod_version = 3.1.0
 
 # https://fabricmc.net/develop
 minecraft_version = 1.21.1
-minecraft_dependency = >=1.21.1 <=1.21.2
+minecraft_dependency = >=1.21 <=1.21.1
 loader_version = 0.16.7
 fabric_api_version = 0.105.0+1.21.1
+fabric_api_dependency = >=0.100.7
 
 # Mixin Extra's
 # https://github.com/LlamaLad7/MixinExtras

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
   "environment": "*",
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric-api": ">=${fabric_api_version}",
+    "fabric-api": "${fabric_api_dependency}",
     "minecraft": "${minecraft_dependency}",
     "java": ">=${java_version}"
   },

--- a/src/main/resources/template.fabric.mod.json
+++ b/src/main/resources/template.fabric.mod.json
@@ -15,7 +15,7 @@
   "environment": "*",
   "depends": {
     "fabricloader": ">=${loader_version}",
-    "fabric-api": ">=${fabric_api_version}",
+    "fabric-api": "${fabric_api_dependency}",
     "minecraft": "${minecraft_dependency}",
     "java": ">=${java_version}"
   },


### PR DESCRIPTION
It shouldn't hurt to do this.

If you're a player, I'm sorry that you're stuck on this version.

If you're a modder who has done what the branch's title is, update your damn mod version!
`~1.21` is good enough even, it's better to error on future MC versions instead of what's a patch version.