### PR TITLE
Fix player position desync when travelling through an ITeleporter portal

### DIFF
--- a/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/ServerPlayerMixin.java
+++ b/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/ServerPlayerMixin.java
@@ -91,6 +91,9 @@ public abstract class ServerPlayerMixin extends Player {
 	@Shadow
 	protected abstract void createEndPlatform(ServerLevel world, BlockPos centerPos);
 
+	@Shadow
+	public abstract void setServerLevel(ServerLevel serverLevel);
+
 	@Inject(method = "<init>", at = @At("RETURN"))
 	private void port_lib$init(MinecraftServer minecraftServer, ServerLevel serverLevel, GameProfile gameProfile, CallbackInfo ci) {
 		ServerPlayerCreationCallback.EVENT.invoker().onCreate((ServerPlayer) (Object) this);
@@ -133,10 +136,10 @@ public abstract class ServerPlayerMixin extends Player {
 
 					serverlevel.getProfiler().pop();
 					serverlevel.getProfiler().push("placing");
-					this.setLevel(p_9180_);
+					this.setServerLevel(p_9180_);
+					this.connection.teleport(portalinfo.pos.x, portalinfo.pos.y, portalinfo.pos.z, portalinfo.yRot, portalinfo.xRot);
+					this.connection.resetPosition();
 					p_9180_.addDuringPortalTeleport((ServerPlayer) (Object) this);
-					this.setRot(portalinfo.yRot, portalinfo.xRot);
-					this.moveTo(portalinfo.pos.x, portalinfo.pos.y, portalinfo.pos.z);
 					serverlevel.getProfiler().pop();
 					this.triggerDimensionChangeTriggers(serverlevel);
 					return this;//forge: this is part of the ITeleporter patch


### PR DESCRIPTION
This PR replicates some code from the Forge `ServerPlayer#changeDimension` patch that is missing in PortingLib's mixin, this seems to be responsible for properly syncing the player's destination position to the client player object.