### PR TITLE
Implement model events

### DIFF
--- a/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/PortingLibModels.java
+++ b/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/PortingLibModels.java
@@ -8,9 +8,16 @@ import io.github.fabricators_of_create.porting_lib.models.util.TransformationHel
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
 import net.minecraft.client.renderer.block.model.BlockModel;
+import net.minecraft.client.resources.model.ModelResourceLocation;
 import net.minecraft.resources.ResourceLocation;
 
 public class PortingLibModels implements ClientModInitializer {
+	public static final String STANDALONE_VARIANT = "standalone";
+
+	public static ModelResourceLocation standalone(ResourceLocation id) {
+		return new ModelResourceLocation(id, STANDALONE_VARIANT);
+	}
+
 	@Override
 	public void onInitializeClient() {
 		ModelLoadingPlugin.register(PortingLibModelLoadingRegistry.INSTANCE);

--- a/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/events/client/ModelEvent.java
+++ b/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/events/client/ModelEvent.java
@@ -1,0 +1,211 @@
+package io.github.fabricators_of_create.porting_lib.models.events.client;
+
+import com.google.common.base.Preconditions;
+
+import io.github.fabricators_of_create.porting_lib.core.event.BaseEvent;
+
+import io.github.fabricators_of_create.porting_lib.core.event.CancellableEvent;
+import io.github.fabricators_of_create.porting_lib.models.PortingLibModels;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.EventFactory;
+import net.minecraft.client.renderer.block.BlockModelShaper;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.ModelBakery;
+import net.minecraft.client.resources.model.ModelManager;
+
+import net.minecraft.client.resources.model.ModelResourceLocation;
+
+import net.minecraft.resources.ResourceLocation;
+
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Houses events related to models.
+ */
+public abstract class ModelEvent extends BaseEvent {
+	@ApiStatus.Internal
+	protected ModelEvent() {}
+
+	/**
+	 * Fired while the {@link ModelManager} is reloading models, after the model registry is set up, but before it's
+	 * passed to the {@link BlockModelShaper} for caching.
+	 *
+	 * <p>
+	 * This event is fired from a worker thread and it is therefore not safe to access anything outside the
+	 * model registry and {@link ModelBakery} provided in this event.<br>
+	 * The {@link ModelManager} firing this event is not fully set up with the latest data when this event fires and
+	 * must therefore not be accessed in this event.
+	 * </p>
+	 *
+	 * <p>Prefer modification events under {@link ModelLoadingPlugin.Context} where possible.</p>
+	 *
+	 * <p>This event is not {@linkplain CancellableEvent cancellable}, and does not have a result.</p>
+	 *
+	 * <p>This event is fired only on the {@linkplain EnvType#CLIENT logical client}.</p>
+	 */
+	public static class ModifyBakingResult extends ModelEvent {
+		public static final Event<Callback> EVENT = EventFactory.createArrayBacked(Callback.class, callbacks -> event -> {
+			for (Callback callback : callbacks) {
+				callback.onModifyBakingResult(event);
+			}
+		});
+
+		public interface Callback {
+			void onModifyBakingResult(ModifyBakingResult event);
+		}
+
+		@Override
+		public void sendEvent() {
+			EVENT.invoker().onModifyBakingResult(this);
+		}
+
+		private final Map<ModelResourceLocation, BakedModel> models;
+		private final Function<Material, TextureAtlasSprite> textureGetter;
+		private final ModelBakery modelBakery;
+
+		@ApiStatus.Internal
+		public ModifyBakingResult(Map<ModelResourceLocation, BakedModel> models, Function<Material, TextureAtlasSprite> textureGetter, ModelBakery modelBakery) {
+			this.models = models;
+			this.textureGetter = textureGetter;
+			this.modelBakery = modelBakery;
+		}
+
+		/**
+		 * @return the modifiable registry map of models and their model names
+		 */
+		public Map<ModelResourceLocation, BakedModel> getModels() {
+			return models;
+		}
+
+		/**
+		 * Returns a lookup function to retrieve {@link TextureAtlasSprite}s by name from any of the atlases handled by
+		 * the {@link ModelManager}. See {@link ModelManager#VANILLA_ATLASES} for the atlases accessible through the
+		 * returned function
+		 *
+		 * @return a function to lookup sprites from an atlas by name
+		 */
+		public Function<Material, TextureAtlasSprite> getTextureGetter() {
+			return textureGetter;
+		}
+
+		/**
+		 * @return the model loader
+		 */
+		public ModelBakery getModelBakery() {
+			return modelBakery;
+		}
+	}
+
+	/**
+	 * Fired when the {@link ModelManager} is notified of the resource manager reloading.
+	 * Called after the model registry is set up and cached in the {@link BlockModelShaper}.<br>
+	 * The model registry given by this event is unmodifiable. To modify the model registry, use
+	 * {@link ModelEvent.ModifyBakingResult} instead.
+	 *
+	 * <p>This event is not {@linkplain CancellableEvent cancellable}, and does not have a result.</p>
+	 *
+	 * <p>This event is fired only on the {@linkplain EnvType#CLIENT logical client}.</p>
+	 */
+	public static class BakingCompleted extends ModelEvent {
+		public static final Event<Callback> EVENT = EventFactory.createArrayBacked(Callback.class, callbacks -> event -> {
+			for (Callback callback : callbacks) {
+				callback.onBakingCompleted(event);
+			}
+		});
+
+		public interface Callback {
+			void onBakingCompleted(BakingCompleted event);
+		}
+
+		@Override
+		public void sendEvent() {
+			EVENT.invoker().onBakingCompleted(this);
+		}
+
+		private final ModelManager modelManager;
+		private final Map<ModelResourceLocation, BakedModel> models;
+		private final ModelBakery modelBakery;
+
+		@ApiStatus.Internal
+		public BakingCompleted(ModelManager modelManager, Map<ModelResourceLocation, BakedModel> models, ModelBakery modelBakery) {
+			this.modelManager = modelManager;
+			this.models = models;
+			this.modelBakery = modelBakery;
+		}
+
+		/**
+		 * @return the model manager
+		 */
+		public ModelManager getModelManager() {
+			return modelManager;
+		}
+
+		/**
+		 * @return an unmodifiable view of the registry map of models and their model names
+		 */
+		public Map<ModelResourceLocation, BakedModel> getModels() {
+			return models;
+		}
+
+		/**
+		 * @return the model loader
+		 */
+		public ModelBakery getModelBakery() {
+			return modelBakery;
+		}
+	}
+
+	/**
+	 * Fired when the {@link ModelBakery} is notified of the resource manager reloading.
+	 * Allows developers to register models to be loaded, along with their dependencies. Models registered through this
+	 * event must use the {@link PortingLibModels#STANDALONE_VARIANT} variant.
+	 * <p>Prefer {@link ModelLoadingPlugin.Context#addModels(ResourceLocation...)} where possible.</p>
+	 *
+	 * <p>This event is not {@linkplain CancellableEvent cancellable}, and does not have a result.</p>
+	 *
+	 * <p>This event is fired only on the {@linkplain EnvType#CLIENT logical client}.</p>
+	 */
+	public static class RegisterAdditional extends ModelEvent {
+		public static final Event<Callback> EVENT = EventFactory.createArrayBacked(Callback.class, callbacks -> event -> {
+			for (Callback callback : callbacks) {
+				callback.onRegisterAdditional(event);
+			}
+		});
+
+		public interface Callback {
+			void onRegisterAdditional(RegisterAdditional event);
+		}
+
+		@Override
+		public void sendEvent() {
+			EVENT.invoker().onRegisterAdditional(this);
+		}
+
+		private final Set<ModelResourceLocation> models;
+
+		@ApiStatus.Internal
+		public RegisterAdditional(Set<ModelResourceLocation> models) {
+			this.models = models;
+		}
+
+		/**
+		 * Registers a model to be loaded, along with its dependencies.
+		 * <p>
+		 * The {@link ModelResourceLocation} passed to this method must later be used to recover the loaded model.
+		 */
+		public void register(ModelResourceLocation model) {
+			Preconditions.checkArgument(
+					model.getVariant().equals(PortingLibModels.STANDALONE_VARIANT),
+					"Side-loaded models must use the '" + PortingLibModels.STANDALONE_VARIANT + "' variant");
+			models.add(model);
+		}
+	}
+}

--- a/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/mixin/client/ModelBakeryMixin.java
+++ b/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/mixin/client/ModelBakeryMixin.java
@@ -1,0 +1,40 @@
+package io.github.fabricators_of_create.porting_lib.models.mixin.client;
+
+import io.github.fabricators_of_create.porting_lib.models.events.client.ModelEvent;
+import net.minecraft.client.color.block.BlockColors;
+import net.minecraft.client.resources.model.ModelBakery;
+
+import net.minecraft.client.resources.model.ModelResourceLocation;
+import net.minecraft.client.resources.model.UnbakedModel;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.profiling.ProfilerFiller;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Mixin(ModelBakery.class)
+public abstract class ModelBakeryMixin {
+	@Shadow
+	abstract UnbakedModel getModel(ResourceLocation modelLocation);
+
+	@Shadow
+	protected abstract void registerModelAndLoadDependencies(ModelResourceLocation modelLocation, UnbakedModel model);
+
+	@Inject(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/resources/model/ModelBakery;loadSpecialItemModelAndDependencies(Lnet/minecraft/client/resources/model/ModelResourceLocation;)V", ordinal = 1, shift = At.Shift.AFTER))
+	private void registerAdditionalModels(BlockColors blockColors, ProfilerFiller profilerFiller, Map modelResources, Map blockStateResources, CallbackInfo ci) {
+		Set<ModelResourceLocation> additionalModels = new HashSet<>();
+		(new ModelEvent.RegisterAdditional(additionalModels)).sendEvent();
+
+		for (ModelResourceLocation model : additionalModels) {
+			UnbakedModel unbakedModel = this.getModel(model.id());
+			this.registerModelAndLoadDependencies(model, unbakedModel);
+		}
+	}
+}

--- a/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/mixin/client/ModelManagerMixin.java
+++ b/modules/models/src/main/java/io/github/fabricators_of_create/porting_lib/models/mixin/client/ModelManagerMixin.java
@@ -1,0 +1,67 @@
+package io.github.fabricators_of_create.porting_lib.models.mixin.client;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import net.minecraft.client.resources.model.BakedModel;
+import net.minecraft.client.resources.model.ModelResourceLocation;
+
+import org.slf4j.Logger;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import io.github.fabricators_of_create.porting_lib.models.events.client.ModelEvent;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
+import net.minecraft.client.resources.model.AtlasSet;
+import net.minecraft.client.resources.model.Material;
+import net.minecraft.client.resources.model.ModelBakery;
+import net.minecraft.client.resources.model.ModelManager;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.profiling.ProfilerFiller;
+
+@Mixin(ModelManager.class)
+public abstract class ModelManagerMixin {
+	@Shadow
+	@Final
+	private static Logger LOGGER;
+
+	@Shadow
+	private Map<ModelResourceLocation, BakedModel> bakedRegistry;
+
+	@Definition(id = "popPush", method = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V")
+	@Definition(id = "profilerFiller", local = @Local(type = ProfilerFiller.class, argsOnly = true))
+	@Expression("profilerFiller.popPush('dispatch')")
+	@Inject(method = "loadModels", at = @At("MIXINEXTRAS:EXPRESSION"))
+	private void modifyBakingResult(ProfilerFiller profilerFiller, Map<ResourceLocation, AtlasSet.StitchResult> atlasPreparations, ModelBakery modelBakery, CallbackInfoReturnable<ModelManager.ReloadState> cir) {
+		profilerFiller.popPush("porting_lib_modify_baking_result");
+
+		Function<Material, TextureAtlasSprite> textureGetter = material -> {
+			AtlasSet.StitchResult stitchResult = atlasPreparations.get(material.atlasLocation());
+			TextureAtlasSprite sprite = stitchResult.getSprite(material.texture());
+			if (sprite != null) {
+				return sprite;
+			}
+			LOGGER.warn("Failed to retrieve texture '{}' from atlas '{}'", material.texture(), material.atlasLocation(), new Throwable());
+			return stitchResult.missing();
+		};
+
+		(new ModelEvent.ModifyBakingResult(modelBakery.getBakedTopLevelModels(), textureGetter, modelBakery)).sendEvent();
+	}
+
+	@Definition(id = "profiler", local = @Local(type = ProfilerFiller.class, argsOnly = true))
+	@Definition(id = "popPush", method = "Lnet/minecraft/util/profiling/ProfilerFiller;popPush(Ljava/lang/String;)V")
+	@Expression("profiler.popPush('cache')")
+	@Inject(method = "apply", at = @At("MIXINEXTRAS:EXPRESSION"))
+	private void callBakingCompletedEvent(ModelManager.ReloadState reloadState, ProfilerFiller profiler, CallbackInfo ci, @Local ModelBakery modelBakery) {
+		(new ModelEvent.BakingCompleted((ModelManager) (Object) this, this.bakedRegistry, modelBakery)).sendEvent();
+	}
+}

--- a/modules/models/src/main/resources/porting_lib_models.mixins.json
+++ b/modules/models/src/main/resources/porting_lib_models.mixins.json
@@ -27,5 +27,8 @@
     "BlockParticleOptionMixin",
     "EntityMixin",
     "LivingEntityMixin"
-  ]
+  ],
+  "mixinextras": {
+    "minVersion": "0.5.0-rc.2"
+  }
 }

--- a/modules/models/src/main/resources/porting_lib_models.mixins.json
+++ b/modules/models/src/main/resources/porting_lib_models.mixins.json
@@ -11,6 +11,8 @@
     "client.ItemRendererMixin",
     "client.ItemTransformDeserializerMixin",
     "client.ItemTransformMixin",
+    "client.ModelBakeryMixin",
+    "client.ModelManagerMixin",
     "client.ParticleEngineMixin",
     "client.ScreenEffectRendererMixin",
     "client.TerrainParticle$ProviderMixin",

--- a/modules/models/src/testmod/java/io/github/fabricators_of_create/porting_lib/models/testmod/client/PortingLibModelsTestmodClient.java
+++ b/modules/models/src/testmod/java/io/github/fabricators_of_create/porting_lib/models/testmod/client/PortingLibModelsTestmodClient.java
@@ -11,7 +11,7 @@ public class PortingLibModelsTestmodClient implements ClientModInitializer {
 	public void onInitializeClient() {
 		ModelResourceLocation location = new ModelResourceLocation(BuiltInRegistries.ITEM.getKey(PortingLibModelsTestmod.DERPY_HELMET), "inventory");
 		ModelLoadingPlugin.register(pluginCtx -> pluginCtx.modifyModelAfterBake().register(
-				(model, ctx) -> ctx.topLevelId().equals(location) ? new DerpyItemModel(model) : model
+				(model, ctx) -> location.equals(ctx.topLevelId()) ? new DerpyItemModel(model) : model
 		));
 	}
 }


### PR DESCRIPTION
- Reimplements model events, as Fabric's ModelLoadingPlugin doesn't seem to cover enough use cases that Forge mods use.
  - Avoids implementing RegisterGeometryLoaders, as that's already handled by RegisterGeometryLoadersCallback in the `model_loaders` module.
  - Also displays the Fabric API alternatives in the javadocs.