### PR TITLE
create lazy supplier for cures to fix early holder access crashes

### DIFF
--- a/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/MobEffectInstanceMixin.java
+++ b/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/MobEffectInstanceMixin.java
@@ -32,7 +32,7 @@ public class MobEffectInstanceMixin implements MobEffectInstanceInjection {
 	private Holder<MobEffect> effect;
 
 	@Unique
-	private final Supplier<Set<EffectCure>> porting_lib$cures = Suppliers.memoize(() -> {
+	private Supplier<Set<EffectCure>> porting_lib$cures = Suppliers.memoize(() -> {
 		var set = Sets.<EffectCure>newIdentityHashSet();
 		this.effect.value().fillEffectCures(set, MixinHelper.cast(this));
 		return set;
@@ -56,4 +56,14 @@ public class MobEffectInstanceMixin implements MobEffectInstanceInjection {
 		getCures().clear();
 		getCures().addAll(effectInstance.getCures());
 	}
+
+	@Inject(method = "<init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/effect/MobEffectInstance$Details;)V", at = @At("TAIL"))
+	private void loadEffects(Holder<MobEffect> effect, MobEffectInstance.Details details, CallbackInfo ci) {
+		var detailsCures = ((MobEffectInstance$DetailsInjection) (Object) details).port_lib$getCures();
+		detailsCures.ifPresent(set -> {
+			this.porting_lib$cures = () -> set;
+		});
+	}
+
+
 }

--- a/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/MobEffectInstanceMixin.java
+++ b/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/MobEffectInstanceMixin.java
@@ -1,5 +1,7 @@
 package io.github.fabricators_of_create.porting_lib.entity.mixin.common;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.Sets;
 
 import com.llamalad7.mixinextras.injector.ModifyReturnValue;
@@ -30,25 +32,17 @@ public class MobEffectInstanceMixin implements MobEffectInstanceInjection {
 	private Holder<MobEffect> effect;
 
 	@Unique
-	private final Set<EffectCure> porting_lib$cures = Sets.newIdentityHashSet();
+	private final Supplier<Set<EffectCure>> porting_lib$cures = Suppliers.memoize(() -> {
+		var set = Sets.<EffectCure>newIdentityHashSet();
+		this.effect.value().fillEffectCures(set, MixinHelper.cast(this));
+		return set;
+	});
 
 	/**
 	 * {@return the {@link EffectCure}s which can cure the {@link MobEffect} held by this {@link MobEffectInstance}}
 	 */
 	public Set<EffectCure> getCures() {
-		return porting_lib$cures;
-	}
-
-	@Inject(method = "<init>(Lnet/minecraft/core/Holder;IIZZZLnet/minecraft/world/effect/MobEffectInstance;)V", at = @At("TAIL"))
-	private void addEffects(Holder<MobEffect> holder, int duration, int amplifier, boolean ambient, boolean visible, boolean showIcon, MobEffectInstance hiddenEffect, CallbackInfo ci) {
-		this.effect.value().fillEffectCures(this.porting_lib$cures, MixinHelper.cast(this));
-	}
-
-	@Inject(method = "<init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/effect/MobEffectInstance$Details;)V", at = @At("TAIL"))
-	private void loadEffects(Holder<MobEffect> effect, MobEffectInstance.Details details, CallbackInfo ci) {
-		Set<EffectCure> cures = getCures();
-		cures.clear();
-		((MobEffectInstance$DetailsInjection) (Object) details).port_lib$getCures().ifPresent(cures::addAll);
+		return porting_lib$cures.get();
 	}
 
 	@ModifyReturnValue(method = "asDetails", at = @At("RETURN"))


### PR DESCRIPTION
Currently in the `MobEffectInstanceMixin` when populating the list of cures, you are accessing the `value` of the passed effect holder too soon for some use cases.
Specifically the following, where a mod creates an effect and also an item with this effect in it's food properties.
The deffered holder of the effect is passed to the `MobEffectInstance` constructor, but du to porting lib is accessed there directly to create the list of cures.

This PR changes this behaviour by moving the cure population to a lazy supplier, therefore only loading once it's accessed the first time and the underlying effect holder has actually been registered.

Mentioned example:
```java
public static final RegistryEntry<MobEffect, ModdedEffect> FOOD_EFFECT = REGISTRATE
            .generic("food_effect", Registries.MOB_EFFECT, ModdedEffect::new)
            .register();

 public static final ItemEntry<Item> FOOD_ITEM = REGISTRATE
            .item("food_item", Item::new)
            .properties(it -> it.food(
                        new FoodProperties.Builder()
                                .effect(new MobEffectInstance(FOOD_EFFECT, 20 * 40, 0), 1.0F)
                                .nutrition(2)
                                .saturationModifier(0.1F)
                .build()
            ))
            .register();
```