### PR TITLE
Fix PlayerAttributesExtensions reporting smaller reach than on Forge

### DIFF
--- a/modules/attributes/src/main/java/io/github/fabricators_of_create/porting_lib/attributes/extensions/PlayerAttributesExtensions.java
+++ b/modules/attributes/src/main/java/io/github/fabricators_of_create/porting_lib/attributes/extensions/PlayerAttributesExtensions.java
@@ -1,6 +1,7 @@
 package io.github.fabricators_of_create.porting_lib.attributes.extensions;
 
-import io.github.fabricators_of_create.porting_lib.attributes.PortingLibAttributes;
+import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
@@ -14,7 +15,7 @@ public interface PlayerAttributesExtensions {
 	}
 
 	default double getBlockReach() {
-		double reach = self().getAttributeValue(PortingLibAttributes.BLOCK_REACH);
+		double reach = ReachEntityAttributes.getReachDistance(self(), 4.5);
 		return reach == 0 ? 0 : reach + (self().isCreative() ? 0.5 : 0);
 	}
 
@@ -35,7 +36,7 @@ public interface PlayerAttributesExtensions {
 	 * @return The entity reach of this player.
 	 */
 	default double getEntityReach() {
-		double range = self().getAttributeValue(PortingLibAttributes.ENTITY_REACH);
+		double range = ReachEntityAttributes.getAttackRange(self(), 3.0);
 		return range == 0 ? 0 : range + (self().isCreative() ? 3 : 0);
 	}
 


### PR DESCRIPTION
Porting Lib has long deferred (3ed5c3e74a0518c4ed1844f8257857d0dc1c719f) its reach attributes to Reach Entity Attributes, but that defines its attributes as purely additive to the base, instead of Forge's (and that of Porting Lib's initial port, which the extension is based on and was seemingly overlooked in the switch to REA) being the entire value, resulting in different reach values being reported (if without there being additions to the attribute, no difference between survival/creative, and worst case if also without padding (which callers at least can change but it is very inconvenient to have to remember to add those base values), no reach at all) for the otherwise very useful methods in PlayerAttributesExtensions.

This PR queries the reach via REA's methods instead of adding the base values manually upon query because that means Porting Lib's extension methods automatically work with REA integrations such as https://github.com/Virtuoel/Pehkui/blob/fabric/1.14.4-1.x.x/src/main/java/virtuoel/pehkui/mixin/reach/compat/ReachEntityAttributesMixin.java

Fixes #116 