### PR TITLE
Fixed bug in ItemHandlerHelper

### DIFF
--- a/modules/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemHandlerHelper.java
+++ b/modules/transfer/src/main/java/io/github/fabricators_of_create/porting_lib/transfer/item/ItemHandlerHelper.java
@@ -20,7 +20,7 @@ public class ItemHandlerHelper {
 	 */
 	public static void giveItemToPlayer(Player player, @Nonnull ItemStack stack) {
 		try (Transaction tx = TransferUtil.getTransaction()) {
-			PlayerInventoryStorage.of(player).offerOrDrop(ItemVariant.of(stack.getItem()), stack.getCount(), tx);
+			PlayerInventoryStorage.of(player).offerOrDrop(ItemVariant.of(stack), stack.getCount(), tx);
 			tx.commit();
 		}
 	}


### PR DESCRIPTION
Calling the overload of ItemVariant#of(...) that takes ItemLike instead of ItemStack causes components to be discarded. This was causing my filled maps to become invalid and lose all of their data. This issue does not occur on NeoForge or when using Mojang's Inventory helper method.