### PR TITLE
Add publishing block for root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,3 +235,26 @@ subprojects {
 		}
 	}
 }
+
+publishing {
+	repositories {
+		maven {
+			name = "devOS"
+			String mavenType = System.getenv("RELEASE") == "true" ? "releases" : "snapshots"
+			url = "https://mvn.devos.one/$mavenType/"
+			credentials {
+				username = System.getenv("MAVEN_USER")
+				password = System.getenv("MAVEN_PASS")
+			}
+			authentication {
+				register("basic", BasicAuthentication)
+			}
+		}
+	}
+
+	publications {
+		register("mavenJava", MavenPublication) {
+			from((SoftwareComponent) components["java"])
+		}
+	}
+}


### PR DESCRIPTION
This will currently produce *io.github.fabricators_of_create.Porting-Lib:Porting-Lib:3.1.0+1.21.1:Porting-Lib-3.1.0+1.21.1.jar*. Do let me know if any changes to that artifact path are desired. The fat jar is around 4.5MB in size, and that is presumably with some degree of optimization already being applied by the build plugin. Not including MixinExtras will bring the size down to around 3.9MB, but that could potentially cause issues depending on what Fabric version dependent mods are using. Depending on the fat jar instead of the modules reduces the size of my mod by around 12MB. This change is pretty much the bare minimum, but if any other optimizations are desired, I could try to handle them in this PR as well.