### PR TITLE
Fix crash when clearing immutable cures in MobEffectInstanceMixin.copyEffects.

### DIFF
--- a/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/MobEffectInstanceMixin.java
+++ b/modules/entity/src/main/java/io/github/fabricators_of_create/porting_lib/entity/mixin/common/MobEffectInstanceMixin.java
@@ -22,6 +22,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 
@@ -53,17 +54,20 @@ public class MobEffectInstanceMixin implements MobEffectInstanceInjection {
 
 	@Inject(method = "setDetailsFrom", at = @At("TAIL"))
 	private void copyEffects(MobEffectInstance effectInstance, CallbackInfo ci) {
-		getCures().clear();
-		getCures().addAll(effectInstance.getCures());
+		// Replace the cures with a mutable copy of the source instance's cures instead of mutating this
+		// instance's set in place: when this instance was loaded from NBT, its cures are an ImmutableSet
+		// (PortingLibExtraCodecs.setOf decodes with ImmutableSet::copyOf), so clear() would throw
+		// UnsupportedOperationException.
+		this.porting_lib$cures = Suppliers.memoize(() -> new HashSet<>(effectInstance.getCures()));
 	}
 
 	@Inject(method = "<init>(Lnet/minecraft/core/Holder;Lnet/minecraft/world/effect/MobEffectInstance$Details;)V", at = @At("TAIL"))
 	private void loadEffects(Holder<MobEffect> effect, MobEffectInstance.Details details, CallbackInfo ci) {
 		var detailsCures = ((MobEffectInstance$DetailsInjection) (Object) details).port_lib$getCures();
 		detailsCures.ifPresent(set -> {
-			this.porting_lib$cures = () -> set;
+			// The set decoded from NBT/network is immutable (see PortingLibExtraCodecs.setOf), but getCures()
+			// is documented to be modifiable, so keep a mutable copy instead of aliasing the decoded set.
+			this.porting_lib$cures = Suppliers.memoize(() -> new HashSet<>(set));
 		});
 	}
-
-
 }


### PR DESCRIPTION
MobEffectInstanceMixin.copyEffects cleared the cures set of the effect instance being updated in place. When the instance was loaded from NBT, its cures are an ImmutableSet (PortingLibExtraCodecs.setOf decodes with ImmutableSet::copyOf), so clear() threw UnsupportedOperationException whenever a saved effect with a hidden_effect expired (setDetailsFrom -> copyEffects).

Fix by replacing the cures with a mutable copy of the source instance's cures instead of mutating in place, and by wrapping the set decoded from Details in a mutable copy during loadEffects so getCures() always returns a modifiable set as documented.

I had mentioned this issue before on [kilt](https://github.com/KiltMC/Kilt/issues/955), but I couldn't figure out which mod was causing it. However, it's always a crash caused by porting. 

Recently, after I ported The Twilight Forest to Fabric 1.21.1 again and loaded it in an environment with quite a few mods, the same issue popped up. 

So I dug into the problem and found a reproduction method.

Reproduction steps:
Game version: 1.21.1 Fabric
- The Twilight Forest [(development version)](https://github.com/Ovear-Mitama/twilightforest-fabric/tree/1.21.1) built-in porting_Lib_version=3.1.0-beta.87
- Fabric API 0.116.15 1.21.1
- Traveler's Backpack 1.21.1-10.1.38
- Cardinal Components API 6.1.3
- Cloth Config API 15.0.140 fabric
- Force Beacon Load 1.0.2 mc1.21.1
- Fabric Language Kotlin 1.13.13 kotlin.2.4.10
- owo-lib-0.13.0-alpha.15 1.21
- accessories-fabric-1.1.0-beta.53 1.21.1

Steps:
Create a superflat world in the game and set up 4 max-level beacons, activating Strength II and Instant Health(main), Haste II, Resistance II, and Swiftness II. Then wear the "Dragon Traveler's Backpack" and leave the beacon's loading range. Once the effects wear off, the game will crash.

Crash log: https://mclo.gs/ZjJb46d
If the link is dead, please refer to this one 
[latest.log](https://github.com/user-attachments/files/30804208/latest.log)
